### PR TITLE
Fix for invalid initial target position

### DIFF
--- a/automation1App/src/Automation1MotorAxis.cpp
+++ b/automation1App/src/Automation1MotorAxis.cpp
@@ -268,7 +268,6 @@ asynStatus Automation1MotorAxis::poll(bool* moving)
     int enabled;
     double programPositionFeedback;
     double programVelocityFeedback;
-    //double programPositionCommand;
     int axisFaults;
     int done;
     

--- a/automation1App/src/Automation1MotorAxis.cpp
+++ b/automation1App/src/Automation1MotorAxis.cpp
@@ -283,6 +283,11 @@ asynStatus Automation1MotorAxis::poll(bool* moving)
     double resolution;
     pC_->getDoubleParam(axisNo_, pC_->motorRecResolution_, &resolution);
 
+    asynPrint(pC_->pasynUserSelf, ASYN_TRACEIO_DRIVER,
+              "getDoubleparam(%d): motor record resolution = %lf\n",
+              axisNo_,
+              resolution);
+
     // This actually retrieves the status items from the controller.
     if (!Automation1_Status_GetResults(pC_->controller_,
                                        statusConfig_,
@@ -314,6 +319,11 @@ asynStatus Automation1MotorAxis::poll(bool* moving)
         pollSuccessfull = false;
         goto skip;
     }
+
+    asynPrint(pC_->pasynUserSelf, ASYN_TRACEIO_DRIVER,
+              "Automation1_Status_GetAxisValue(%d): counts per unit = %lf\n",
+              axisNo_,
+              countsPerUnitParam);
 
     enabled = driveStatus & Automation1DriveStatus_Enabled;
     setIntegerParam(pC_->motorStatusPowerOn_, enabled);

--- a/automation1App/src/Automation1MotorAxis.cpp
+++ b/automation1App/src/Automation1MotorAxis.cpp
@@ -276,7 +276,7 @@ asynStatus Automation1MotorAxis::poll(bool* moving)
     int enabled;
     double programPositionFeedback;
     double programVelocityFeedback;
-    double programPositionCommand;
+    //double programPositionCommand;
     double countsPerUnitParam;
     int axisFaults;
     int done;
@@ -297,6 +297,14 @@ asynStatus Automation1MotorAxis::poll(bool* moving)
     programPositionFeedback = results[2];
     programVelocityFeedback = results[3];
     axisFaults = (int)results[4];
+
+    asynPrint(pC_->pasynUserSelf, ASYN_TRACEIO_DRIVER,
+              "Automation1_Status_GetResults(%d): axis status = %d; drive status = %d; position feedback = %lf; velocity feedback %lf\n",
+              axisNo_,
+              axisStatus,
+              driveStatus,
+              programPositionFeedback,
+              programVelocityFeedback);
 
     if (!Automation1_Parameter_GetAxisValue(pC_->controller_,
         axisNo_,

--- a/automation1App/src/Automation1MotorAxis.h
+++ b/automation1App/src/Automation1MotorAxis.h
@@ -44,7 +44,9 @@ private:
     // calls to the C API.  To avoid duplicate code, we wrap calls 
     // to those functions and to asynPrint in this function.
     void logError(const char* driverMessage);
-
+    
+    double countsPerUnitParam_;    
+    
     friend class Automation1MotorController;
 };
 

--- a/iocs/automation1IOC/iocBoot/iocAutomation1/automation1.cmd
+++ b/iocs/automation1IOC/iocBoot/iocAutomation1/automation1.cmd
@@ -1,7 +1,14 @@
 
 Automation1CreateController("Automation1", "127.0.0.1", 4, 100, 1000)
 
+# traceError and traceIODriver
+#!asynSetTraceMask("Automation1", 0, 0x9)
+# traceIOAscii
+#!asynSetTraceIOMask("Automation1", 0, 0x1)
+
 Automation1CreateProfile("Automation1", 2000)
 
 dbLoadTemplate "motor.substitutions.automation1"
+
+dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=Auto1:, R=asyn1, PORT=Automation1, ADDR=0, OMAX=256, IMAX=256")
 


### PR DESCRIPTION
Use countsPerUnitParam (read from the controller) instead of resolution (the motor record's resolution) in all non-profile methods.

The invalid target position was occuring because the resolution was zero while the IOC was starting.

Fixes #5 