### PR TITLE
Bug fix: Ensure Automation1MotorController::dataControllerConfig_ is initialised to NULL

### DIFF
--- a/automation1App/src/Automation1MotorController.cpp
+++ b/automation1App/src/Automation1MotorController.cpp
@@ -40,6 +40,7 @@ Automation1MotorController::Automation1MotorController(const char* portName, con
         1, // autoconnect
         0, 0)    // Default priority and stack size
 {
+    dataCollectionConfig_ = NULL;
     pAxes_ = (Automation1MotorAxis**)(asynMotorController::pAxes_);
 
     createAsynParams();


### PR DESCRIPTION
In some situations the `Automation1MotorController::dataControllerConfig_` is not NULL for first call of `Automation1MotorController::buildProfile`, where the configuration is supposed to be created.  This would result in a segmentation fault at some point later.