### PR TITLE
Fix: Profile move units should match normal axis move

### DIFF
--- a/automation1App/src/Automation1MotorAxis.cpp
+++ b/automation1App/src/Automation1MotorAxis.cpp
@@ -403,35 +403,6 @@ skip:
     return pollSuccessfull ? asynSuccess : asynError;
 }
 
-/** Function to define the motor positions for a profile move.
-  * This function calls the base class method, then converts the positions to
-  * controller units.
-  * \param[in] positions Array of profile positions for this axis in user units.
-  * \param[in] numPoints The number of positions in the array.
-  */
-asynStatus Automation1MotorAxis::defineProfile(double* positions, size_t numPoints)
-{
-    double resolution;
-    pC_->getDoubleParam(axisNo_, pC_->motorRecResolution_, &resolution);
-    // Call the base class function (converts from EGU to steps)
-    asynStatus status = asynMotorAxis::defineProfile(positions, numPoints);
-    if (status) return status;
-
-    // Convert from steps to EGU.
-    for (size_t i = 0; i < numPoints; i++)
-    {
-        profilePositions_[i] = profilePositions_[i] * resolution;
-    }
-    return asynSuccess;
-}
-
-asynStatus Automation1MotorAxis::readbackProfile()
-{
-    // Call the base class method
-    asynMotorAxis::readbackProfile();
-    return asynSuccess;
-}
-
 /** Logs an driver error and error details from the C API.  Made to reduce duplicate code.
   * \param[in] driverMessage A char array meant to convey where in execution the error occured.
 */

--- a/automation1App/src/Automation1MotorAxis.h
+++ b/automation1App/src/Automation1MotorAxis.h
@@ -28,10 +28,6 @@ public:
     asynStatus setPosition(double position);
     asynStatus setClosedLoop(bool closedLoop);
 
-    // Needed for profile motion.
-    asynStatus defineProfile(double* positions, size_t numPoints);
-    asynStatus readbackProfile();
-
 private:
     // Pointer to asynMotorController to which the axis belongs.
     Automation1MotorController* pC_;

--- a/automation1App/src/Automation1MotorController.h
+++ b/automation1App/src/Automation1MotorController.h
@@ -50,7 +50,6 @@ public:
     asynStatus readbackProfile();
 
     asynStatus poll() override;
-
 protected:
 
     // Array of pointers to axis objects.
@@ -74,10 +73,6 @@ private:
 
     // Axes to be used in a profile move.
     std::vector<int> profileAxes_;
-
-    // The resolution of the motor axes. Needed for profile motion 
-    // because Automation1 works in EGU, not steps.
-    std::vector<double> profileAxesResolutions_;
 
     // Convience wrapper for reporting Automation1 API errors
     void logApiError(const char* driverMessage) {


### PR DESCRIPTION
The conversion from positions specified by the user in EGU to positions consumed by the Automation1 controller in "User Units", is not the same when performing a profile move compared to setting a demand position via the motor record VAL field.  This PR changes how the conversion is done for a profile move to match the a move done by setting a demand position.

To do this, we use the base implementation for `automation1MotorAxis::defineProfile` and `automation1MotorAxis::readbackProfile`.  This means that the positions stored in the `asynMotorAxis::profilePositions_`
array are in encoder counts.  We then convert to and from controller User Units using the "CountsPerUnit" parameter.

