### PR TITLE
Allow the user to specify the task indices

### DIFF
--- a/automation1App/src/Automation1MotorController.h
+++ b/automation1App/src/Automation1MotorController.h
@@ -15,7 +15,6 @@
 #include <cstdarg>
 
 #define MAX_AUTOMATION1_AXES 32
-#define PROFILE_MOVE_TASK_INDEX 2
 #define PROFILE_MOVE_ABORT_TIMEOUT 1000
 #define DATA_POINTS_PER_SECOND 1000
 
@@ -41,7 +40,7 @@ class epicsShareClass Automation1MotorController : public asynMotorController
 {
 public:
     // Member functions we override from the base class.
-    Automation1MotorController(const char* portName, const char* hostName, int numAxes, double movingPollPeriod, double idlePollPeriod);
+    Automation1MotorController(const char* portName, const char* hostName, int numAxes, double movingPollPeriod, double idlePollPeriod, int commandExecuteTask, int profileMoveTask);
     ~Automation1MotorController();
     void report(FILE* fp, int level);
     Automation1MotorAxis* getAxis(asynUser* pasynUser);
@@ -90,6 +89,10 @@ private:
     // A handle that will be used to specify the data logged for
     // readbacks.
     Automation1DataCollectionConfig dataCollectionConfig_;
+    
+    // User-specified task indices
+    int32_t commandExecuteTask_;
+    int32_t profileMoveTask_;
     
     // The total number of data collection points
     int numDataPoints_;

--- a/iocs/automation1IOC/iocBoot/iocAutomation1/automation1.cmd
+++ b/iocs/automation1IOC/iocBoot/iocAutomation1/automation1.cmd
@@ -1,5 +1,12 @@
-
-Automation1CreateController("Automation1", "164.54.104.47", 4, 100, 1000)
+# Automation1CreateController(
+#   const char* portName,    # asyn port name
+#   const char* hostName,    # hostname or ip address
+#   int numAxes,
+#   int movingPollPeriod,    # unit: milliseconds
+#   int idlePollPeriod,      # unit: milliseconds
+#   int commandExecuteTask,  # default task index: 1
+#   int profileMoveTask)     # default task index: 2
+Automation1CreateController("Automation1", "127.0.0.1", 4, 100, 1000, 1, 2)
 
 # traceError and traceIODriver
 #!asynSetTraceMask("Automation1", 0, 0x9)


### PR DESCRIPTION
Allow the user to specify the task indices for the command execute and profile move tasks to avoid conflicts with hexapod programs.