### PR TITLE
Fix build on Windows and non-supported archs

### DIFF
--- a/automation1App/src/Automation1MotorController.cpp
+++ b/automation1App/src/Automation1MotorController.cpp
@@ -1345,7 +1345,7 @@ done:
 asynStatus Automation1MotorController::poll()
 {
     Automation1DataCollectionStatus dataCollectionStatus;
-    Automation1TaskStatus taskStatusArray[profileMoveTask_ + 1];
+    Automation1TaskStatus *taskStatusArray = new Automation1TaskStatus[profileMoveTask_ + 1];
     Automation1TaskStatus* taskStatus;
     int executeState = PROFILE_EXECUTE_DONE;
     int numPoints;
@@ -1401,7 +1401,7 @@ done:
     {
         callParamCallbacks();
     }
-
+    delete[] taskStatusArray;
     return pollOk ? asynSuccess : asynError;
 }
 

--- a/automation1App/src/Makefile
+++ b/automation1App/src/Makefile
@@ -9,7 +9,8 @@ ifeq (win32-x86-static, $(findstring win32-x86, $(T_A)))
 USR_LDFLAGS += /NODEFAULTLIB:MSVCRT
 endif
 
-LIBRARY_IOC = Automation1
+LIBRARY_IOC_WIN32 = Automation1
+LIBRARY_IOC_Linux = Automation1
 
 SRCS += Automation1MotorAxis.cpp
 SRCS += Automation1MotorController.cpp


### PR DESCRIPTION
The change to the driver allows building on Windows, which does not support automatic array variables with non-constant dimensions.

The change to Makefile prevents building on non-supported archs like vxWorks.

