### PR TITLE
Use OS_CLASS to detect Linux target architectures

### DIFF
--- a/automation1App/src/Makefile
+++ b/automation1App/src/Makefile
@@ -27,9 +27,13 @@ ifeq (win32-x86, $(findstring win32-x86, $(T_A)))
 	Automation1_LIBS += automation1c
 else ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
 	Automation1_LIBS += automation1c64
-else ifeq (linux-x86_64, $(findstring linux-x86_64, $(T_A)))
+# Use OS_CLASS check for linux to avoid breaking custom Linux arches
+else ifeq ($(OS_CLASS),Linux)
+ifeq (x86_64, $(findstring x86_64, $(T_A)))
 	Automation1_SYS_LIBS += automation1compiler
 	Automation1_SYS_LIBS += automation1c
+endif
+# End OS_CLASS=Linux
 endif
 
 DBD += devAutomation1Motor.dbd

--- a/automation1Sup/Makefile
+++ b/automation1Sup/Makefile
@@ -15,9 +15,13 @@ else ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
 	BIN_INSTALLS += ../Library/Windows/x64/Automation1C64.dll
 	LIB_INSTALLS += ../Library/Windows/x64/Automation1C64.lib
 	BIN_INSTALLS += ../Library/Windows/x64/Automation1Compiler64.dll
-else ifeq (linux-x86_64, $(findstring linux-x86_64, $(T_A)))
+# Use OS_CLASS check for linux to avoid breaking custom Linux arches
+else ifeq ($(OS_CLASS),Linux)
+ifeq (x86_64, $(findstring x86_64, $(T_A)))
 	LIB_INSTALLS += ../Library/Linux/x64/libautomation1c.so
 	LIB_INSTALLS += ../Library/Linux/x64/libautomation1compiler.so
+endif
+# End OS_CLASS=Linux
 endif
 
 #=============================

--- a/iocs/automation1IOC/automation1App/src/Makefile
+++ b/iocs/automation1IOC/automation1App/src/Makefile
@@ -43,9 +43,13 @@ ifeq (win32-x86, $(findstring win32-x86, $(T_A)))
 	PROD_LIBS += automation1c
 else ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
 	PROD_LIBS += automation1c64
-else ifeq (linux-x86_64, $(findstring linux-x86_64, $(T_A)))
+# Use OS_CLASS check for linux to avoid breaking custom Linux arches
+else ifeq ($(OS_CLASS),Linux)
+ifeq (x86_64, $(findstring x86_64, $(T_A)))
 	PROD_SYS_LIBS += automation1compiler
 	PROD_SYS_LIBS += automation1c
+endif
+# End OS_CLASS=Linux
 endif
 
 # Add all the support libraries needed by this IOC


### PR DESCRIPTION
Use OS_CLASS to detect Linux target architectures, to avoid breaking builds for custom linux architures