### PR TITLE
Add position compare output

### DIFF
--- a/automation1App/Db/Automation1MotorAxis.template
+++ b/automation1App/Db/Automation1MotorAxis.template
@@ -79,3 +79,50 @@ record(bo, "$(P)$(M)FEMAXRESET")
     field(VAL, "0")
     field(OUT, "$(P)$(M)FERRORMAX.VAL")
 }
+
+##############################################################
+# PSO distance source.  
+# These are the Automation1PsoDistanceInput values defined in Automation1Enum.h
+# For example, the primary encoder feedback on the iXL5e is 190
+# Automation1PsoDistanceInput_iXL5ePrimaryFeedback = 190
+##############################################################
+record(longout, "$(P)$(M)PSODistanceInput")
+{
+    field(DESC, "PSO distance input")
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT=4))AUTOMATION1_PSO_DISTANCE_INPUT")
+    field(VAL,  "$(PSO_DISTANCE_INPUT=0)")
+}
+
+##############################################################
+# PSO window source.  
+# These are the Automation1PsoWindowInput values defined in Automation1Enum.h
+# For example, the primary encoder feedback on the iXL5e is 190
+# Automation1PsoWindowInput_iXL5ePrimaryFeedback = 190
+##############################################################
+record(longout, "$(P)$(M)PSOWindowInput")
+{
+    field(DESC, "PSO distance input")
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT=4))AUTOMATION1_PSO_WINDOW_INPUT")
+    field(VAL,  "$(PSO_WINDOW_INPUT=0)")
+}
+
+##############################################################
+# PSO output pin.  
+# These are the Automation1PsoOutputPin values defined in Automation1Enum.h
+# For example, the auxialiary marker single-ended on the iXL5e is 135
+# Automation1PsoOutputPin_iXL5eAuxiliaryMarkerSingleEnded = 135
+##############################################################
+record(longout, "$(P)$(M)PSOutputPin")
+{
+    field(DESC, "PSO distance input")
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT=4))AUTOMATION1_PSO_OUTPUT_PIN")
+    field(VAL,  "$(PSO_OUTPUT_PIN=0)")
+}
+
+

--- a/automation1App/src/Automation1MotorAxis.cpp
+++ b/automation1App/src/Automation1MotorAxis.cpp
@@ -545,8 +545,9 @@ asynStatus Automation1MotorAxis::enablePCO(bool enable)
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWindowConfigureFixedRange(pC_->controller_, taskNumber, axisNo_, windowNumber, 
-       std::lround(startPosition * countsPerUnitParam_), std::lround(endPosition * countsPerUnitParam_))) {
+  double lowerBound = std::lround(std::min(startPosition, endPosition) * countsPerUnitParam_);
+  double upperBound = std::lround(std::max(startPosition, endPosition) * countsPerUnitParam_);
+  if (!Automation1_Command_PsoWindowConfigureFixedRange(pC_->controller_, taskNumber, axisNo_, windowNumber, lowerBound, upperBound)) {
     logError("Error calling PsoWindowConfigureFixedRange");
     return asynError;
   }

--- a/automation1App/src/Automation1MotorAxis.cpp
+++ b/automation1App/src/Automation1MotorAxis.cpp
@@ -33,6 +33,8 @@ Automation1MotorAxis::Automation1MotorAxis(Automation1MotorController* pC, int a
     pC_(pC)
 {
     fullProfilePositions_ = NULL;
+    Automation1ConfiguredParameters configuredParameters;
+    double direction;
     
     Automation1_StatusConfig_Create(&(statusConfig_));
     Automation1_StatusConfig_AddAxisStatusItem(statusConfig_, axisNo, Automation1AxisStatusItem_AxisStatus, 0);
@@ -42,6 +44,24 @@ Automation1MotorAxis::Automation1MotorAxis(Automation1MotorController* pC, int a
     Automation1_StatusConfig_AddAxisStatusItem(statusConfig_, axisNo, Automation1AxisStatusItem_AxisFault, 0);
     Automation1_StatusConfig_AddAxisStatusItem(statusConfig_, axisNo, Automation1AxisStatusItem_PositionError, 0);
     Automation1_StatusConfig_AddAxisStatusItem(statusConfig_, axisNo, Automation1AxisStatusItem_ProgramPosition, 0);
+
+    // Determine if this axis has reverse direction of encoder and motor direction
+    if (!Automation1_ConfiguredParameters_Create(&configuredParameters)) {
+      logError("Error calling ConfiguredParameters_Create");
+      return;
+    }
+  
+    if (!Automation1_Configuration_GetConfiguredParameters(pC_->controller_, configuredParameters)) {  
+      logError("Error calling GetConfiguredParameters");
+      return;
+    }
+    
+    if (!Automation1_ConfiguredParameters_GetAxisValue(configuredParameters, axisNo_, 
+         Automation1AxisParameterId_ReverseMotionDirection, &direction)) {
+      logError("Error calling ConfiguredParameters_GetAxisValue");
+      return;
+    }
+    reverseDirection_ = (direction != 0);
 
     // Gain Support is required for setClosedLoop to be called
     setIntegerParam(pC->motorStatusGainSupport_, 1);
@@ -452,21 +472,39 @@ skip:
 */
 asynStatus Automation1MotorAxis::enablePCO(bool enable)
 {
-  Automation1PsoDistanceInput pulseSource = Automation1PsoDistanceInput_iXL5ePrimaryFeedback;
-  Automation1PsoWindowInput windowSource =  Automation1PsoWindowInput_iXL5ePrimaryFeedback;
+  Automation1PsoDistanceInput distanceInput;
+  Automation1PsoWindowInput windowInput;
+  Automation1PsoOutputPin outputPin;
+  int recDirection, dir;
+  double recOffset;
+  int iTemp;
   int windowNumber = 0;
-  int clockFrequency = 1e6;
+  int taskNumber = 1;
   double startPosition, endPosition, increment, pulseWidth;
-  
-  pC_->getDoubleParam(axisNo_, pC_->PCOStartPosition_, &startPosition);
-  pC_->getDoubleParam(axisNo_, pC_->PCOEndPosition_,   &endPosition);
-  pC_->getDoubleParam(axisNo_, pC_->PCOIncrement_,     &increment);
-  pC_->getDoubleParam(0,       pC_->PCOPulseWidth_,    &pulseWidth);
 
-  printf("Automation1MotorAxis::enablePCO entry, startPosition=%f, endPosition=%f, increment=%f, pulseWidth=%f, enable=%d\n",
-         startPosition, endPosition, increment, pulseWidth, enable);
+  pC_->getIntegerParam(axisNo_, pC_->AUTOMATION1_PSO_DistanceInput_, &iTemp);
+  distanceInput = (Automation1PsoDistanceInput)iTemp;
+  pC_->getIntegerParam(axisNo_, pC_->AUTOMATION1_PSO_WindowInput_,   &iTemp);
+  windowInput = (Automation1PsoWindowInput)iTemp;
+  pC_->getIntegerParam(axisNo_, pC_->AUTOMATION1_PSO_OutputPin_,     &iTemp);
+  outputPin = (Automation1PsoOutputPin)iTemp;
+  pC_->getDoubleParam(axisNo_,  pC_->PCOStartPosition_, &startPosition);
+  pC_->getDoubleParam(axisNo_,  pC_->PCOEndPosition_,   &endPosition);
+  pC_->getDoubleParam(axisNo_,  pC_->PCOIncrement_,     &increment);
+  pC_->getDoubleParam(axisNo_,  pC_->PCOPulseWidth_,    &pulseWidth);
+  pC_->getIntegerParam(axisNo_, pC_->motorRecDirection_, &recDirection);
+  pC_->getDoubleParam(axisNo_,  pC_->motorRecOffset_,    &recOffset);
 
-  if (!Automation1_Command_PsoReset(pC_->controller_, 1, axisNo_)) {
+  dir = recDirection ? -1 : 1;
+  startPosition = (startPosition - recOffset) * dir;
+  endPosition = (endPosition - recOffset) * dir;
+
+  printf("Automation1MotorAxis::enablePCO entry, startPosition=%f, endPosition=%f, increment=%f, pulseWidth=%f," 
+         "reverseDirection=%d, distanceInput=%d, windowInput=%d, outputPin=%d, recDirection=%d, recOffset=%f, enable=%d\n",
+         startPosition, endPosition, increment, pulseWidth, reverseDirection_, distanceInput, windowInput, outputPin, 
+         recDirection, recOffset, enable);
+
+  if (!Automation1_Command_PsoReset(pC_->controller_, taskNumber, axisNo_)) {
     logError("Error calling PsoReset");
     return asynError;
   }
@@ -476,89 +514,89 @@ asynStatus Automation1MotorAxis::enablePCO(bool enable)
     return asynSuccess;
   }
 
-  Automation1PsoDistanceInput pulseSrc = pulseSource;
-  if (!Automation1_Command_PsoDistanceConfigureInputs(pC_->controller_, 1, axisNo_, &pulseSrc, 1)) {
+  if (!Automation1_Command_PsoDistanceConfigureInputs(pC_->controller_, taskNumber, axisNo_, &distanceInput, 1)) {
     logError("Error calling PsoDistanceConfigureInputs");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoDistanceConfigureFixedDistance(pC_->controller_, 1, axisNo_, std::lround(increment * countsPerUnitParam_))) {
+  if (!Automation1_Command_PsoDistanceConfigureFixedDistance(pC_->controller_, taskNumber, axisNo_, std::lround(increment * countsPerUnitParam_))) {
     logError("Error calling PsoDistanceConfigureFixedDistance");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoDistanceCounterOn(pC_->controller_, 1, axisNo_)) {
+  if (!Automation1_Command_PsoDistanceCounterOn(pC_->controller_, taskNumber, axisNo_)) {
     logError("Error calling PsoDistanceCounterOn");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoDistanceEventsOn(pC_->controller_, 1, axisNo_)) {
+  if (!Automation1_Command_PsoDistanceEventsOn(pC_->controller_, taskNumber, axisNo_)) {
     logError("Error calling PsoDistanceEventsOn");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWindowConfigureInput(pC_->controller_, 1, axisNo_, windowNumber, windowSource, 1)) {
+  if (!Automation1_Command_PsoWindowConfigureInput(pC_->controller_, taskNumber, axisNo_, windowNumber, windowInput, reverseDirection_)) {
     logError("Error calling PsoWindowConfigureInput");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWindowCounterSetValue(pC_->controller_, 1, axisNo_, windowNumber, std::lround(programPosition_ * countsPerUnitParam_))) {
+  if (!Automation1_Command_PsoWindowCounterSetValue(pC_->controller_, taskNumber, axisNo_, windowNumber, 
+       std::lround(programPosition_ * countsPerUnitParam_))) {
     logError("Error calling PsoWindowCCounterSetValue");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWindowConfigureFixedRange(pC_->controller_, 1, axisNo_, windowNumber, 
+  if (!Automation1_Command_PsoWindowConfigureFixedRange(pC_->controller_, taskNumber, axisNo_, windowNumber, 
        std::lround(startPosition * countsPerUnitParam_), std::lround(endPosition * countsPerUnitParam_))) {
     logError("Error calling PsoWindowConfigureFixedRange");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWindowOutputOn(pC_->controller_, 1, axisNo_, windowNumber)) {
+  if (!Automation1_Command_PsoWindowOutputOn(pC_->controller_, taskNumber, axisNo_, windowNumber)) {
     logError("Error calling PsoWindowOutputOn");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoEventConfigureMask(pC_->controller_, 1, axisNo_, Automation1PsoEventMask_WindowMask)) {
+  if (!Automation1_Command_PsoEventConfigureMask(pC_->controller_, taskNumber, axisNo_, Automation1PsoEventMask_WindowMask)) {
     logError("Error calling PsoEventConfigureMask");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWaveformConfigureMode(pC_->controller_, 1, axisNo_, Automation1PsoWaveformMode_Pulse)) {
+  if (!Automation1_Command_PsoWaveformConfigureMode(pC_->controller_, taskNumber, axisNo_, Automation1PsoWaveformMode_Pulse)) {
     logError("Error calling PsoWaveformConfigureMode");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWaveformConfigurePulseFixedTotalTime(pC_->controller_, 1, axisNo_, std::lround(pulseWidth * clockFrequency))) {
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedTotalTime(pC_->controller_, taskNumber, axisNo_, pulseWidth * 1.e6)) {
     logError("Error calling PsoWaveformConfigurePulseFixedTotalTime");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWaveformConfigurePulseFixedOnTime(pC_->controller_, 1, axisNo_, std::lround(pulseWidth * clockFrequency))) {
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedOnTime(pC_->controller_, taskNumber, axisNo_, pulseWidth * 1.e6)) {
     logError("Error calling PsoWaveformConfigurePulseFixedOnTime");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWaveformConfigurePulseFixedCount(pC_->controller_, 1, axisNo_, 1)) {
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedCount(pC_->controller_, taskNumber, axisNo_, 1)) {
     logError("Error calling PsoWaveformConfigurePulseFixedCount");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWaveformApplyPulseConfiguration(pC_->controller_, 1, axisNo_)) {
+  if (!Automation1_Command_PsoWaveformApplyPulseConfiguration(pC_->controller_, taskNumber, axisNo_)) {
     logError("Error calling PsoWaveformApplyPulseConfiguration");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoWaveformOn(pC_->controller_, 1, axisNo_)) {
+  if (!Automation1_Command_PsoWaveformOn(pC_->controller_, taskNumber, axisNo_)) {
     logError("Error calling PsoWaveformOn");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoOutputConfigureSource(pC_->controller_, 1, axisNo_, Automation1PsoOutputSource_Waveform)) {
+  if (!Automation1_Command_PsoOutputConfigureSource(pC_->controller_, taskNumber, axisNo_, Automation1PsoOutputSource_Waveform)) {
     logError("Error calling PsoOutputConfigureSource");
     return asynError;
   }
 
-  if (!Automation1_Command_PsoOutputConfigureOutput(pC_->controller_, 1, axisNo_, Automation1PsoOutputPin_iXL5eAuxiliaryMarkerSingleEnded)) {
+  if (!Automation1_Command_PsoOutputConfigureOutput(pC_->controller_, taskNumber, axisNo_, outputPin)) {
     logError("Error calling PsoOutputConfigureOutput");
     return asynError;
   }

--- a/automation1App/src/Automation1MotorAxis.cpp
+++ b/automation1App/src/Automation1MotorAxis.cpp
@@ -41,6 +41,7 @@ Automation1MotorAxis::Automation1MotorAxis(Automation1MotorController* pC, int a
     Automation1_StatusConfig_AddAxisStatusItem(statusConfig_, axisNo, Automation1AxisStatusItem_ProgramVelocityFeedback, 0);
     Automation1_StatusConfig_AddAxisStatusItem(statusConfig_, axisNo, Automation1AxisStatusItem_AxisFault, 0);
     Automation1_StatusConfig_AddAxisStatusItem(statusConfig_, axisNo, Automation1AxisStatusItem_PositionError, 0);
+    Automation1_StatusConfig_AddAxisStatusItem(statusConfig_, axisNo, Automation1AxisStatusItem_ProgramPosition, 0);
 
     // Gain Support is required for setClosedLoop to be called
     setIntegerParam(pC->motorStatusGainSupport_, 1);
@@ -311,7 +312,7 @@ asynStatus Automation1MotorAxis::defineProfile(double *positions, size_t numPoin
 asynStatus Automation1MotorAxis::poll(bool* moving)
 {
     bool pollSuccessfull = true;
-    double results[6];
+    double results[7];
     int axisStatus;
     int driveStatus;
     int enabled;
@@ -336,6 +337,7 @@ asynStatus Automation1MotorAxis::poll(bool* moving)
     programVelocityFeedback = results[3];
     axisFaults = (int)results[4];
     positionError = results[5];
+    programPosition_ = results[6];
 
     asynPrint(pC_->pasynUserSelf, ASYN_TRACEIO_DRIVER,
               "Automation1_Status_GetResults(%d): axis status = %d; drive status = %d; position feedback = %lf; velocity feedback %lf\n",
@@ -442,6 +444,127 @@ skip:
     }
 
     return pollSuccessfull ? asynSuccess : asynError;
+}
+
+/** Enables or disables position compare output
+  *
+  * \param[in] enable A flag to enable (true) or disable (false) PCO
+*/
+asynStatus Automation1MotorAxis::enablePCO(bool enable)
+{
+  Automation1PsoDistanceInput pulseSource = Automation1PsoDistanceInput_iXL5ePrimaryFeedback;
+  Automation1PsoWindowInput windowSource =  Automation1PsoWindowInput_iXL5ePrimaryFeedback;
+  int windowNumber = 0;
+  int clockFrequency = 1e6;
+  double startPosition, endPosition, increment, pulseWidth;
+  
+  pC_->getDoubleParam(axisNo_, pC_->PCOStartPosition_, &startPosition);
+  pC_->getDoubleParam(axisNo_, pC_->PCOEndPosition_,   &endPosition);
+  pC_->getDoubleParam(axisNo_, pC_->PCOIncrement_,     &increment);
+  pC_->getDoubleParam(0,       pC_->PCOPulseWidth_,    &pulseWidth);
+
+  printf("Automation1MotorAxis::enablePCO entry, startPosition=%f, endPosition=%f, increment=%f, pulseWidth=%f, enable=%d\n",
+         startPosition, endPosition, increment, pulseWidth, enable);
+
+  if (!Automation1_Command_PsoReset(pC_->controller_, 1, axisNo_)) {
+    logError("Error calling PsoReset");
+    return asynError;
+  }
+  
+  // If enable is 0 we are done
+  if (enable == 0) {
+    return asynSuccess;
+  }
+
+  Automation1PsoDistanceInput pulseSrc = pulseSource;
+  if (!Automation1_Command_PsoDistanceConfigureInputs(pC_->controller_, 1, axisNo_, &pulseSrc, 1)) {
+    logError("Error calling PsoDistanceConfigureInputs");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoDistanceConfigureFixedDistance(pC_->controller_, 1, axisNo_, std::lround(increment * countsPerUnitParam_))) {
+    logError("Error calling PsoDistanceConfigureFixedDistance");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoDistanceCounterOn(pC_->controller_, 1, axisNo_)) {
+    logError("Error calling PsoDistanceCounterOn");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoDistanceEventsOn(pC_->controller_, 1, axisNo_)) {
+    logError("Error calling PsoDistanceEventsOn");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWindowConfigureInput(pC_->controller_, 1, axisNo_, windowNumber, windowSource, 1)) {
+    logError("Error calling PsoWindowConfigureInput");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWindowCounterSetValue(pC_->controller_, 1, axisNo_, windowNumber, std::lround(programPosition_ * countsPerUnitParam_))) {
+    logError("Error calling PsoWindowCCounterSetValue");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWindowConfigureFixedRange(pC_->controller_, 1, axisNo_, windowNumber, 
+       std::lround(startPosition * countsPerUnitParam_), std::lround(endPosition * countsPerUnitParam_))) {
+    logError("Error calling PsoWindowConfigureFixedRange");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWindowOutputOn(pC_->controller_, 1, axisNo_, windowNumber)) {
+    logError("Error calling PsoWindowOutputOn");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoEventConfigureMask(pC_->controller_, 1, axisNo_, Automation1PsoEventMask_WindowMask)) {
+    logError("Error calling PsoEventConfigureMask");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWaveformConfigureMode(pC_->controller_, 1, axisNo_, Automation1PsoWaveformMode_Pulse)) {
+    logError("Error calling PsoWaveformConfigureMode");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedTotalTime(pC_->controller_, 1, axisNo_, std::lround(pulseWidth * clockFrequency))) {
+    logError("Error calling PsoWaveformConfigurePulseFixedTotalTime");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedOnTime(pC_->controller_, 1, axisNo_, std::lround(pulseWidth * clockFrequency))) {
+    logError("Error calling PsoWaveformConfigurePulseFixedOnTime");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedCount(pC_->controller_, 1, axisNo_, 1)) {
+    logError("Error calling PsoWaveformConfigurePulseFixedCount");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWaveformApplyPulseConfiguration(pC_->controller_, 1, axisNo_)) {
+    logError("Error calling PsoWaveformApplyPulseConfiguration");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoWaveformOn(pC_->controller_, 1, axisNo_)) {
+    logError("Error calling PsoWaveformOn");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoOutputConfigureSource(pC_->controller_, 1, axisNo_, Automation1PsoOutputSource_Waveform)) {
+    logError("Error calling PsoOutputConfigureSource");
+    return asynError;
+  }
+
+  if (!Automation1_Command_PsoOutputConfigureOutput(pC_->controller_, 1, axisNo_, Automation1PsoOutputPin_iXL5eAuxiliaryMarkerSingleEnded)) {
+    logError("Error calling PsoOutputConfigureOutput");
+    return asynError;
+  }
+  printf("Automation1MotorAxis::enablePCO exit success\n");
+  return asynSuccess;
+
 }
 
 /** Logs an driver error and error details from the C API.  Made to reduce duplicate code.

--- a/automation1App/src/Automation1MotorAxis.h
+++ b/automation1App/src/Automation1MotorAxis.h
@@ -28,6 +28,7 @@ public:
     asynStatus setPosition(double position);
     asynStatus setClosedLoop(bool closedLoop);
     asynStatus defineProfile(double *positions, size_t numPoints);
+    asynStatus enablePCO(bool enable);
 
 private:
     // Pointer to asynMotorController to which the axis belongs.
@@ -43,6 +44,7 @@ private:
     void logError(const char* driverMessage);
     
     double countsPerUnitParam_;
+    double programPosition_;
     
     double profilePreDistance_;
     double profilePrePosition_;

--- a/automation1App/src/Automation1MotorAxis.h
+++ b/automation1App/src/Automation1MotorAxis.h
@@ -54,6 +54,9 @@ private:
     
     double *fullProfilePositions_;
     int32_t fullProfilePositionsIndex_;
+
+    // Flag indicating that the sign of the motor and encoder direction are reversed
+    bool reverseDirection_;
     
     friend class Automation1MotorController;
 };

--- a/automation1App/src/Automation1MotorController.cpp
+++ b/automation1App/src/Automation1MotorController.cpp
@@ -36,7 +36,7 @@ static const char *driverName = "Automation1MotorController";
   * \param[in] idlePollPeriod     The time between polls when no axis is moving.
 */
 Automation1MotorController::Automation1MotorController(const char* portName, const char* hostName, int numAxes, double movingPollPeriod, double idlePollPeriod, int commandExecuteTask, int profileMoveTask)
-    : asynMotorController(portName, numAxes, NUM_AUTOMATION1_PARAMS,
+    : asynMotorController(portName, numAxes, 0,
         0, // No additional interfaces beyond those in base class
         0, // No additional callback interfaces beyond those in base class
         ASYN_CANBLOCK | ASYN_MULTIDEVICE,
@@ -130,6 +130,11 @@ void Automation1MotorController::createAsynParams(void)
     createParam(AUTOMATION1_PM_PulseSrcString,     asynParamInt32,        &AUTOMATION1_PM_PulseSrc_);
     createParam(AUTOMATION1_PM_PulseOutString,     asynParamInt32,        &AUTOMATION1_PM_PulseOut_);
     createParam(AUTOMATION1_PM_PulseAxisString,    asynParamInt32,        &AUTOMATION1_PM_PulseAxis_);
+    //
+    createParam(AUTOMATION1_PSO_DistanceInputString, asynParamInt32,     &AUTOMATION1_PSO_DistanceInput_);
+    createParam(AUTOMATION1_PSO_WindowInputString,   asynParamInt32,     &AUTOMATION1_PSO_WindowInput_);
+    createParam(AUTOMATION1_PSO_OutputPinString,     asynParamInt32,     &AUTOMATION1_PSO_OutputPin_);
+
 }
 
 /* * Creates a new Automation1 controller object.
@@ -222,7 +227,7 @@ asynStatus Automation1MotorController::writeFloat64Array(asynUser *pasynUser, ep
     int function = pasynUser->reason;
     asynMotorAxis *pAxis;
     asynStatus status = asynSuccess;
-    static const char *functionName = "writeFloat64Array";
+    //static const char *functionName = "writeFloat64Array";
     
     pAxis = getAxis(pasynUser);
     if (!pAxis) return asynError;
@@ -713,6 +718,7 @@ asynStatus Automation1MotorController::buildProfile()
     
     for (i = 0; i < numSegments; i++)
     {
+        segmentTime = 0;
         for (j = 0; j < numUsedAxes; j++)
         {
             axis = pAxes_[profileAxes_[j]];

--- a/automation1App/src/Automation1MotorController.h
+++ b/automation1App/src/Automation1MotorController.h
@@ -35,7 +35,11 @@
 #define AUTOMATION1_PM_PulseSrcString       "AUTOMATION1_PM_PULSE_SRC"
 #define AUTOMATION1_PM_PulseOutString       "AUTOMATION1_PM_PULSE_OUT"
 #define AUTOMATION1_PM_PulseAxisString      "AUTOMATION1_PM_PULSE_AXIS"
-#define NUM_AUTOMATION1_PARAMS 15
+// PSO configuration parameters, model-specific
+#define AUTOMATION1_PSO_DistanceInputString "AUTOMATION1_PSO_DISTANCE_INPUT"
+#define AUTOMATION1_PSO_WindowInputString   "AUTOMATION1_PSO_WINDOW_INPUT"
+#define AUTOMATION1_PSO_OutputPinString     "AUTOMATION1_PSO_OUTPUT_PIN"
+
 
 
 class epicsShareClass Automation1MotorController : public asynMotorController
@@ -82,7 +86,10 @@ protected:
     int AUTOMATION1_PM_PulseSrc_;
     int AUTOMATION1_PM_PulseOut_;
     int AUTOMATION1_PM_PulseAxis_;
-    int parameters[NUM_AUTOMATION1_PARAMS];
+    int AUTOMATION1_PSO_DistanceInput_;
+    int AUTOMATION1_PSO_WindowInput_;
+    int AUTOMATION1_PSO_OutputPin_;
+
 
 private:
 

--- a/automation1App/src/Makefile
+++ b/automation1App/src/Makefile
@@ -12,8 +12,8 @@ endif
 LIBRARY_IOC_WIN32 = Automation1
 LIBRARY_IOC_Linux = Automation1
 
-SRCS += Automation1MotorAxis.cpp
-SRCS += Automation1MotorController.cpp
+Automation1_SRCS += Automation1MotorAxis.cpp
+Automation1_SRCS += Automation1MotorController.cpp
 
 ifdef MOTOR_AUTOMATION1
 automation1compiler_DIR += $(MOTOR_AUTOMATION1)/bin/$(EPICS_HOST_ARCH)
@@ -37,6 +37,15 @@ endif
 endif
 
 DBD += devAutomation1Motor.dbd
+
+PROD += PSOTest
+PSOTest_SRCS += PSOTest.cpp
+ifeq ($(OS_CLASS),Linux)
+ifeq (x86_64, $(findstring x86_64, $(T_A)))
+	PSOTest_SYS_LIBS += automation1compiler
+	PSOTest_SYS_LIBS += automation1c
+endif
+endif
 
 Automation1_LIBS += motor asyn
 Automation1_LIBS += $(EPICS_BASE_IOC_LIBS)

--- a/automation1App/src/PSOTest.cpp
+++ b/automation1App/src/PSOTest.cpp
@@ -1,0 +1,192 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <cmath>
+#include "Include/Automation1.h"
+
+#define ENCODER_COUNTS_PER_DEGREE 253770
+#define DEGREES_PER_PULSE 0.01
+#define AXIS_NUMBER 0
+#define TASK_INDEX 1
+#define AXIS 0
+#define PULSE_WIDTH_SEC .001
+#define CLOCK_FREQUENCY 1e6
+#define DUTY_CYCLE 0.5
+#define WINDOW_NUMBER 0
+#define PULSE_SRC Automation1PsoDistanceInput_iXL5ePrimaryFeedback
+#define WINDOW_SRC Automation1PsoWindowInput_iXL5ePrimaryFeedback
+#define START_ANGLE 0.
+#define STOP_ANGLE 180.
+
+/// <summary>
+/// Gets the most recent error from the controller and prints it for the user.
+/// </summary>
+void printError()
+{
+	// When a function from the C API fails, an error code and message are stored. We can use 
+	// Automation1_GetLastError() to get the most recent error code from the controller. Note 
+	// that a subsequent error will overwrite the currently stored code and message.
+	int32_t lastError = Automation1_GetLastError();
+
+	// We can then use Automation1_GetLastErrorMessage(buffer, bufferLength) to populate a char array with
+	// the error message.
+	char lastErrorMessage[2048];
+	Automation1_GetLastErrorMessage(lastErrorMessage, 2048);
+
+	printf("    error (%d): %s\n", lastError, lastErrorMessage);
+}
+
+int32_t main(int32_t argc, char** argv) 
+{
+  Automation1Controller controller = NULL;
+  Automation1StatusConfig statusConfig = NULL;
+  double programPosition;
+  
+  
+  printf("Calling Automation1_ConnectWithHost\n");
+  if (!Automation1_ConnectWithHost("10.54.160.251", &controller)) {
+    printError();
+    exit(-1);
+  }
+  
+  printf("Calling Automation1_Command_SetupTaskTargetMode\n");
+  if (!Automation1_Command_SetupTaskTargetMode(controller, TASK_INDEX, Automation1TargetMode_Absolute)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_StatusConfig_Create\n");
+  if (!Automation1_StatusConfig_Create(&statusConfig)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_StatusConfig_AddAxisStatusItem\n");
+  if (!Automation1_StatusConfig_AddAxisStatusItem(statusConfig, AXIS, Automation1AxisStatusItem_ProgramPosition, 0)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Status_GetResults\n");
+  if (!Automation1_Status_GetResults(controller, statusConfig, &programPosition, 1)) {
+    printError();
+    exit(-1);
+  }
+  printf("Program position=%f\n", programPosition);
+  
+  printf("Calling Automation1_Command_PsoReset\n");
+  if (!Automation1_Command_PsoReset(controller, TASK_INDEX, AXIS)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoDistanceConfigureInputs\n");
+  Automation1PsoDistanceInput pulseSrc = PULSE_SRC;
+  if (!Automation1_Command_PsoDistanceConfigureInputs(controller, TASK_INDEX, AXIS, &pulseSrc, 1)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoDistanceConfigureFixedDistance\n");
+  if (!Automation1_Command_PsoDistanceConfigureFixedDistance(controller, TASK_INDEX, AXIS, 
+       std::lround(DEGREES_PER_PULSE * ENCODER_COUNTS_PER_DEGREE))) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoDistanceCounterOn\n");
+  if (!Automation1_Command_PsoDistanceCounterOn(controller, TASK_INDEX, AXIS)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoDistanceEventsOn\n");
+  if (!Automation1_Command_PsoDistanceEventsOn(controller, TASK_INDEX, AXIS)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWindowConfigureInput\n");
+  if (!Automation1_Command_PsoWindowConfigureInput(controller, TASK_INDEX, AXIS, WINDOW_NUMBER, WINDOW_SRC, 1)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWindowCCounterSetValue\n");
+  if (!Automation1_Command_PsoWindowCounterSetValue(controller, TASK_INDEX, AXIS, WINDOW_NUMBER, 
+       std::lround(programPosition*ENCODER_COUNTS_PER_DEGREE))) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWindowConfigureFixedRange\n");
+  if (!Automation1_Command_PsoWindowConfigureFixedRange(controller, TASK_INDEX, AXIS, WINDOW_NUMBER, 
+       START_ANGLE*ENCODER_COUNTS_PER_DEGREE, STOP_ANGLE*ENCODER_COUNTS_PER_DEGREE)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWindowOutputOn\n");
+  if (!Automation1_Command_PsoWindowOutputOn(controller, TASK_INDEX, AXIS, WINDOW_NUMBER)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoEventConfigureMask\n");
+  if (!Automation1_Command_PsoEventConfigureMask(controller, TASK_INDEX, AXIS, Automation1PsoEventMask_WindowMask)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWaveformConfigureMode\n");
+  if (!Automation1_Command_PsoWaveformConfigureMode(controller, TASK_INDEX, AXIS, Automation1PsoWaveformMode_Pulse)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWaveformConfigurePulseFixedTotalTime\n");
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedTotalTime(controller, TASK_INDEX, AXIS, 
+       std::lround(PULSE_WIDTH_SEC * CLOCK_FREQUENCY))) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWaveformConfigurePulseFixedOnTime\n");
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedOnTime(controller, TASK_INDEX, AXIS, 
+       std::lround(PULSE_WIDTH_SEC * CLOCK_FREQUENCY * DUTY_CYCLE))) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWaveformConfigurePulseFixedCount\n");
+  if (!Automation1_Command_PsoWaveformConfigurePulseFixedCount(controller, TASK_INDEX, AXIS, 1)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWaveformApplyPulseConfiguration\n");
+  if (!Automation1_Command_PsoWaveformApplyPulseConfiguration(controller, TASK_INDEX, AXIS)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoWaveformOn\n");
+  if (!Automation1_Command_PsoWaveformOn(controller, TASK_INDEX, AXIS)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoOutputConfigureSource\n");
+  if (!Automation1_Command_PsoOutputConfigureSource(controller, TASK_INDEX, AXIS, Automation1PsoOutputSource_Waveform)) {
+    printError();
+    exit(-1);
+  }
+
+  printf("Calling Automation1_Command_PsoOutputConfigureOutput\n");
+  if (!Automation1_Command_PsoOutputConfigureOutput(controller, TASK_INDEX, AXIS, Automation1PsoOutputPin_iXL5eAuxiliaryMarkerSingleEnded)) {
+    printError();
+    exit(-1);
+  }
+
+}
+

--- a/iocs/automation1IOC/iocBoot/iocAutomation1/motor.substitutions.PCO_test
+++ b/iocs/automation1IOC/iocBoot/iocAutomation1/motor.substitutions.PCO_test
@@ -1,0 +1,43 @@
+
+file "$(MOTOR)/db/basic_asyn_motor.db"
+{
+pattern
+{P,      N,       M,        DTYP,         PORT,  ADDR,     DESC,  EGU,   DIR,   VELO,  VBAS, ACCL, BDST, BVEL, BACC,   MRES,          PREC,   DHLM, DLLM,    INIT}
+{Auto1:, 1, "m$(N)", "asynMotor",  Automation1,     0,   "Omega", deg,   Pos,   60.0,   0.1,   .2,    0,    1,   .2,  3.9405768e-6,    3,     3600,  -3600,    ""}
+}
+
+file "$(MOTOR)/db/profileMoveController.template"
+{
+pattern
+{     P,     R,        PORT, NAXES, NPOINTS, NPULSES, TIMEOUT}
+{Auto1:,  pm1:, Automation1,     1,    2000,    2000,       1}
+}
+
+file "$(MOTOR)/db/profileMoveAxis.template"
+{
+pattern
+{     P,      R, M,         PORT, ADDR, NPOINTS, NREADBACK,     MOTOR, PREC, TIMEOUT}
+{Auto1:,   pm1:, 1,  Automation1,    0,    2000,      2000,  Auto1:m1,    3,       1}
+}
+
+file "$(MOTOR)/db/positionCompare.template"
+{
+pattern
+{     P,    M,       PORT,    ADDR, PREC}
+{Auto1:,   m1,  Automation1,    0,   3}
+}
+
+
+file "$(TOP)/db/Automation1MotorController.template"
+{
+pattern
+{     P,        PORT,     TIMEOUT}
+{Auto1:, Automation1,           1}
+}
+
+file "$(TOP)/db/Automation1MotorAxis.template"
+{
+pattern
+{     P,	M,        PORT,	ADDR,    TIMEOUT}
+{Auto1:, 	m1, Automation1,	0,           	1}
+}

--- a/iocs/automation1IOC/iocBoot/iocAutomation1/motor.substitutions.PCO_test
+++ b/iocs/automation1IOC/iocBoot/iocAutomation1/motor.substitutions.PCO_test
@@ -35,9 +35,10 @@ pattern
 {Auto1:, Automation1,           1}
 }
 
+# The PSO values below are for the iXL5e controller
 file "$(TOP)/db/Automation1MotorAxis.template"
 {
 pattern
-{     P,	M,        PORT,	ADDR,    TIMEOUT}
-{Auto1:, 	m1, Automation1,	0,           	1}
+{     P,	M,        PORT,	ADDR,    PSO_DISTANCE_INPUT, PSO_WINDOW_INPUT, PSO_OUTPUT_PIN, TIMEOUT}
+{Auto1:, 	m1, Automation1,	0,         190,                190,             135,          	1}
 }

--- a/iocs/automation1IOC/iocBoot/iocAutomation1/st.cmd.PCO_test
+++ b/iocs/automation1IOC/iocBoot/iocAutomation1/st.cmd.PCO_test
@@ -1,0 +1,21 @@
+#!../../bin/linux-x86_64/automation1
+
+#errlogInit(5000)
+< envPaths
+
+# Tell EPICS all about the record types, device-support modules, drivers, etc.
+dbLoadDatabase("../../dbd/automation1.dbd")
+automation1_registerRecordDeviceDriver(pdbbase)
+
+Automation1CreateController("Automation1", "10.54.160.251", 1, 200, 1000)
+
+Automation1CreateProfile("Automation1", 2000)
+
+### Motors
+dbLoadTemplate "motor.substitutions.PCO_test"
+
+iocInit
+
+# This IOC does not use save/restore, so set values of some PVs
+dbpf("Auto1:m1.RTRY", "0")
+dbpf("Auto1:m1.TWV", "0.1")


### PR DESCRIPTION
This PR adds support for position compare feedback.  It requires this PR from epics-modules/motor:
https://github.com/epics-modules/motor/pull/248.

It includes a test program for the underlying Automation1 calls, and test addtions to the example IOC.

This is the medm screen for configuring the PCO.  Presssing Enable writes the configuration to the controlling, and pressing Disable disables the PCO output.

<img width="787" height="172" alt="Automation1_PCO" src="https://github.com/user-attachments/assets/b46a97bc-a652-4d2f-a411-3bf02589d80c" />
